### PR TITLE
I want to raw lz4 data

### DIFF
--- a/ext/lz4ruby/lz4ruby.c
+++ b/ext/lz4ruby/lz4ruby.c
@@ -3,6 +3,7 @@
 #include "lz4hc.h"
 
 typedef int (*CompressFunc)(const char *source, char *dest, int isize);
+typedef int (*CompressLimitedOutputFunc)(const char* source, char* dest, int inputSize, int maxOutputSize);
 
 static VALUE lz4internal;
 static VALUE lz4_error;
@@ -81,12 +82,167 @@ static VALUE lz4internal_uncompress(VALUE self, VALUE input, VALUE in_size, VALU
   return result;
 }
 
+static inline void lz4internal_raw_compress_scanargs(int argc, VALUE *argv, VALUE *src, VALUE *dest, size_t *srcsize, size_t *maxsize) {
+  switch (argc) {
+  case 1:
+    *src = argv[0];
+    Check_Type(*src, RUBY_T_STRING);
+    *srcsize = RSTRING_LEN(*src);
+    *dest = rb_str_buf_new(0);
+    *maxsize = LZ4_compressBound(*srcsize);
+    break;
+  case 2:
+    *src = argv[0];
+    Check_Type(*src, RUBY_T_STRING);
+    *srcsize = RSTRING_LEN(*src);
+    if (TYPE(argv[1]) == T_STRING) {
+      *dest = argv[1];
+      *maxsize = LZ4_compressBound(*srcsize);
+    } else {
+      *dest = rb_str_buf_new(0);
+      *maxsize = NUM2SIZET(argv[1]);
+    }
+    break;
+  case 3:
+    *src = argv[0];
+    Check_Type(*src, RUBY_T_STRING);
+    *srcsize = RSTRING_LEN(*src);
+    *dest = argv[1];
+    Check_Type(*dest, RUBY_T_STRING);
+    *maxsize = NUM2SIZET(argv[2]);
+    break;
+  default:
+    //rb_error_arity(argc, 1, 3);
+    rb_scan_args(argc, argv, "12", NULL, NULL, NULL);
+    // the following code is used to eliminate compiler warnings.
+    *src = *dest = 0;
+    *srcsize = *maxsize = 0;
+  }
+}
+
+static inline VALUE lz4internal_raw_compress_common(int argc, VALUE *argv, VALUE lz4, CompressLimitedOutputFunc compressor) {
+  VALUE src, dest;
+  size_t srcsize;
+  size_t maxsize;
+
+  lz4internal_raw_compress_scanargs(argc, argv, &src, &dest, &srcsize, &maxsize);
+
+  if (srcsize > LZ4_MAX_INPUT_SIZE) {
+    rb_raise(lz4_error,
+             "input size is too big for lz4 compress (max %u bytes)",
+             LZ4_MAX_INPUT_SIZE);
+  }
+  rb_str_modify(dest);
+  rb_str_resize(dest, maxsize);
+  rb_str_set_len(dest, 0);
+
+  int size = compressor(RSTRING_PTR(src), RSTRING_PTR(dest), srcsize, maxsize);
+  if (size < 0) {
+    rb_raise(lz4_error, "failed LZ4 raw compress");
+  }
+
+  rb_str_resize(dest, size);
+  rb_str_set_len(dest, size);
+
+  return dest;
+}
+
+/*
+ * call-seq:
+ *  (compressed string data)  raw_compress(src)
+ *  (compressed string data)  raw_compress(src, max_dest_size)
+ *  (dest with compressed string data)  raw_compress(src, dest)
+ *  (dest with compressed string data)  raw_compress(src, dest, max_dest_size)
+ */
+static VALUE lz4internal_raw_compress(int argc, VALUE *argv, VALUE lz4i) {
+  return lz4internal_raw_compress_common(argc, argv, lz4i, LZ4_compress_limitedOutput);
+}
+
+/*
+ * call-seq:
+ *  (compressed string data)  raw_compressHC(src)
+ *  (compressed string data)  raw_compressHC(src, max_dest_size)
+ *  (dest with compressed string data)  raw_compressHC(src, dest)
+ *  (dest with compressed string data)  raw_compressHC(src, dest, max_dest_size)
+ */
+static VALUE lz4internal_raw_compressHC(int argc, VALUE *argv, VALUE lz4i) {
+  return lz4internal_raw_compress_common(argc, argv, lz4i, LZ4_compressHC_limitedOutput);
+}
+
+enum {
+  LZ4RUBY_UNCOMPRESS_MAXSIZE = 1 << 24, // tentative value
+};
+
+static inline void lz4internal_raw_uncompress_scanargs(int argc, VALUE *argv, VALUE *src, VALUE *dest, size_t *maxsize) {
+  switch (argc) {
+  case 1:
+    *src = argv[0];
+    Check_Type(*src, RUBY_T_STRING);
+    *dest = rb_str_buf_new(0);
+    *maxsize = LZ4RUBY_UNCOMPRESS_MAXSIZE;
+    break;
+  case 2:
+    *src = argv[0];
+    Check_Type(*src, RUBY_T_STRING);
+    *dest = argv[1];
+    if (TYPE(*dest) == T_STRING) {
+      *maxsize = LZ4RUBY_UNCOMPRESS_MAXSIZE;
+    } else {
+      *maxsize = NUM2SIZET(*dest);
+      *dest = rb_str_buf_new(0);
+    }
+    break;
+  case 3:
+    *src = argv[0];
+    Check_Type(*src, RUBY_T_STRING);
+    *dest = argv[1];
+    Check_Type(*dest, RUBY_T_STRING);
+    *maxsize = NUM2SIZET(argv[2]);
+    break;
+  default:
+    //rb_error_arity(argc, 2, 3);
+    rb_scan_args(argc, argv, "21", NULL, NULL, NULL);
+    // the following code is used to eliminate compiler warnings.
+    *src = *dest = 0;
+    *maxsize = 0;
+  }
+}
+
+/*
+ * call-seq:
+ *  (uncompressed string data)  raw_uncompress(src, max_dest_size = 1 << 24)
+ *  (dest for uncompressed string data)  raw_uncompress(src, dest, max_dest_size = 1 << 24)
+ */
+static VALUE lz4internal_raw_uncompress(int argc, VALUE *argv, VALUE lz4i) {
+  VALUE src, dest;
+  size_t maxsize;
+  lz4internal_raw_uncompress_scanargs(argc, argv, &src, &dest, &maxsize);
+
+  rb_str_modify(dest);
+  rb_str_resize(dest, maxsize);
+  rb_str_set_len(dest, 0);
+
+  int size = LZ4_decompress_safe(RSTRING_PTR(src), RSTRING_PTR(dest), RSTRING_LEN(src), maxsize);
+  if (size < 0) {
+    rb_raise(lz4_error, "failed LZ4 raw uncompress at %d", -size);
+  }
+
+  rb_str_resize(dest, size);
+  rb_str_set_len(dest, size);
+
+  return dest;
+}
+
 void Init_lz4ruby(void) {
   lz4internal = rb_define_module("LZ4Internal");
 
   rb_define_module_function(lz4internal, "compress", lz4internal_compress, 3);
   rb_define_module_function(lz4internal, "compressHC", lz4internal_compressHC, 3);
   rb_define_module_function(lz4internal, "uncompress", lz4internal_uncompress, 4);
+
+  rb_define_module_function(lz4internal, "raw_compress", lz4internal_raw_compress, -1);
+  rb_define_module_function(lz4internal, "raw_compressHC", lz4internal_raw_compressHC, -1);
+  rb_define_module_function(lz4internal, "raw_uncompress", lz4internal_raw_uncompress, -1);
 
   lz4_error = rb_define_class_under(lz4internal, "Error", rb_eStandardError);
 }

--- a/lib/lz4-ruby.rb
+++ b/lib/lz4-ruby.rb
@@ -39,6 +39,18 @@ class LZ4
     return LZ4Internal::uncompress(input, in_size, varbyte_len, out_size)
   end
 
+  def self.raw_compress(*args)
+    LZ4Internal.raw_compress(*args)
+  end
+
+  def self.raw_compressHC(*args)
+    LZ4Internal.raw_compressHC(*args)
+  end
+
+  def self.raw_uncompress(*args)
+    LZ4Internal.raw_uncompress(*args)
+  end
+
   def self.encode_varbyte(val)
     varbytes = []
 


### PR DESCRIPTION
lz4-ruby で圧縮したデータは現状では特有のヘッダが付加され、伸張時にはヘッダを必要としていますが、このヘッダがつかない、必要のない手段が欲しいです。

というわけでちょっといじってみました。対応環境は CRuby のみで、JRuby に対する実装はありません。

ruby-1.9.3 と ruby-2.0.0、ruby-2.1.0 でライブラリ構築とテスト実行までを確認してあります (1.8 系列はサポートが切れているので割愛)。

マージをしてもらえるか、たたき台にでもしてもらえたら幸いです。

追加したメソッドと引数については次のとおりです:
- 圧縮処理
  
  LZ4.raw_compress(src) -> compressed_data
  LZ4.raw_compress(src, max_dest_size) -> compressed_data
  LZ4.raw_compress(src, dest) -> dest_with_compressed_data
  LZ4.raw_compress(src, dest, max_dest_size) -> dest_with_compressed_data
  
  LZ4 の圧縮処理を行います。
  
  これらは src を入力として圧縮し、圧縮データを返します。
  
  出力先としての dest を指定した場合、すでに確保されている文字列オブジェクトが利用されます。
  
  max_dest_size は圧縮後のデータサイズに制限を持たせたい場合に正の整数値で指定します。単位はバイトです。
  これを省略した場合、src の長さから最悪値が計算されます。
- 高効率圧縮処理
  
  LZ4.raw_compressHC(src) -> compressed_data
  LZ4.raw_compressHC(src, max_dest_size) -> compressed_data
  LZ4.raw_compressHC(src, dest) -> dest_with_compressed_data
  LZ4.raw_compressHC(src, dest, max_dest_size) -> dest_with_compressed_data
  
  LZ4 の高効率圧縮を行います。
  
  引数と戻り値は LZ4.raw_compress と同じとなります。
- 伸張処理
  
  LZ4.raw_uncompress(src, max_dest_size = (1 << 24)) -> uncompressed_data
  LZ4.raw_uncompress(src, dest, max_dest_size = (1 << 24)) -> dest_with_uncompressed_data
  
  LZ4 で圧縮されたデータを伸張します。
  
  src は LZ4 によって圧縮されたデータで、これを伸張したデータを返します。
  
  出力先としての dest を指定した場合、すでに確保されている文字列オブジェクトが利用されます。
  
  max_dest_size は伸張後のデータサイズとして正の整数値を与えます。
  これを省略した場合、(1 << 24) の値 (16MiB) が与えられたこととみなされます。
